### PR TITLE
Adapt `@with` to work with minor change from JuliaSyntax.jl

### DIFF
--- a/src/internal.jl
+++ b/src/internal.jl
@@ -36,7 +36,7 @@ macro with(doblock::Expr, bindings...)
         @gensym err ans handled context
         if b isa Symbol
             value = resource = b
-        elseif Meta.isexpr(b, :kw, 2)
+        elseif Meta.isexpr(b, (:kw,:(=)), 2)
             value, resource = b.args
             if value === :_
                 @gensym value


### PR DESCRIPTION
The reference parser parses the `=` in `@x(y=1)` as `Expr(:(=))` but the `=` in `@x(y=1) do y end` as `Expr(:kw)`.  In JuliaSyntax, we've corrected this inconsistency as a minor change to the parsing rules, but this breaks the `@with` macro in this package (And one macro in `Fluxperimental` - the only two cases in General.)

Found as part of the integration work in https://github.com/JuliaLang/julia/pull/46372